### PR TITLE
Fix call to undefined function Composer\Autoload\includeFile() error

### DIFF
--- a/src/Nooku/Composer/Installer/JoomlaExtension.php
+++ b/src/Nooku/Composer/Installer/JoomlaExtension.php
@@ -283,3 +283,15 @@ class JoomlaExtension extends LibraryInstaller
         }
     }
 }
+
+/**
+ * Workaround for Joomla 3.4+
+ * 
+ * Fix Fatal error: Call to undefined function Composer\Autoload\includeFile() in /libraries/ClassLoader.php on line 43
+ */
+namespace Composer\Autoload;
+
+function includeFile($file)
+{
+    include $file;
+}


### PR DESCRIPTION
Redeclare the includeFile() method in the Composer\Autoload namespace. This ensure the [ClassLoaderJoomla::loadClass() in /libraries/ClassLoader.php](https://github.com/joomla/joomla-cms/blob/staging/libraries/ClassLoader.php#L43) can find the method. 

@stevenrombauts I did notice I had to use 'sudo' for `composer update` and `composer require`without I composer had problems writing to it's cache. 
